### PR TITLE
Build from the current stable serie

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -47,6 +47,7 @@ parts:
   evince:
     source: https://gitlab.gnome.org/GNOME/evince.git
     source-type: git
+    source-branch: 'gnome-40'
     plugin: meson
     meson-parameters:
        - --prefix=/snap/evince/current/usr


### PR DESCRIPTION
The current stable build seems to build from upstream master, changing to use gnome-40 instead

