### PR TITLE
bump automation extension version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     lower-than: '45'
+#     lower-than: '46'
 #     no-9x-revisions: true
     plugin: meson
     parse-info: [usr/share/metainfo/org.gnome.Evince.appdata.xml]


### PR DESCRIPTION
bumping automation extension version to pull gnome 45 tags