### PR TITLE
build: bump max upstream version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -52,7 +52,7 @@ parts:
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     lower-than: '46'
+#     lower-than: '47'
 #     no-9x-revisions: true
     plugin: meson
     parse-info: [usr/share/metainfo/org.gnome.Evince.appdata.xml]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
   evince:
     source: https://gitlab.gnome.org/GNOME/evince.git
     source-type: git
-    source-tag: '45.0'
+    source-tag: '46.1'
     source-depth: 1
 # ext:updatesnap
 #   version-format:


### PR DESCRIPTION
This pull request enables the snap to be updated to gnome 46 by the automation