### PR TITLE
Update to 48.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,11 +48,11 @@ parts:
   evince:
     source: https://gitlab.gnome.org/GNOME/evince.git
     source-type: git
-    source-tag: '46.3'
+    source-tag: '48.0'
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     lower-than: '47'
+#     lower-than: '49'
 #     no-9x-revisions: true
     plugin: meson
     parse-info: [usr/share/metainfo/org.gnome.Evince.appdata.xml]


### PR DESCRIPTION
The new version builds and runs without issue locally. Upstream meson requirements didn't change